### PR TITLE
Fix Doctrine dependency to stable tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,24 +22,13 @@
             "email": "dolly.aswin@gmail.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/webimpress/DoctrineModule.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/webimpress/DoctrineORMModule.git"
-        }
-    ],
     "require": {
         "php": "^5.6 || ^7.0",
         "zendframework/zend-modulemanager": "^2.7.1",
         "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",
         "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1",
         "doctrine/data-fixtures": "^1.2.1",
-        "doctrine/doctrine-module": "dev-feature/zf3-support",
-        "doctrine/doctrine-orm-module": "dev-feature/zf3-support"
+        "doctrine/doctrine-orm-module": "^1.1"
     },
     "require-dev": {
         "satooshi/php-coveralls": ">=0.6.0",


### PR DESCRIPTION
Doctrine team already released stable tags on DoctrineModule & DoctrineOrmModule with ZF3 support.
Also pin to doctrine/doctrine-module not needed because doctrine/doctrine-orm-module already have right dependency.
